### PR TITLE
Online users count not showing on toolbar

### DIFF
--- a/static/css/pad.css
+++ b/static/css/pad.css
@@ -58,9 +58,9 @@ textarea {
 /* Position the online count button a bit better */
 li[data-key=showusers] > a #online_count {
     background-color: #000;
-    -webkit-border-radius: 4px !important;
-       -moz-border-radius: 4px !important;
-            border-radius: 4px !important;
+    -webkit-border-radius: 4px;
+       -moz-border-radius: 4px;
+            border-radius: 4px;
     color: #FFF;
     display: inline-block;
     position: absolute;

--- a/static/css/pad.css
+++ b/static/css/pad.css
@@ -55,7 +55,13 @@ textarea {
     min-width: 250px;
 }
 
-/* Position the online count button a bit better */
+/* Position the users button and online count a bit better */
+.toolbar ul li a .buttonicon {
+    display: inline-block !important;
+    left: 3px;
+    position: relative;
+}
+
 li[data-key=showusers] > a #online_count {
     background-color: #000;
     -webkit-border-radius: 4px;
@@ -63,10 +69,10 @@ li[data-key=showusers] > a #online_count {
             border-radius: 4px;
     color: #FFF;
     display: inline-block;
-    position: absolute;
+    font-weight: 700;
     padding: 3px 4px;
-    right: 1px;
-    top: 5px;
+    position: relative;
+    top: -6px;
 }
 
 li[data-key=showusers] > a:focus #online_count,

--- a/static/css/pad.css
+++ b/static/css/pad.css
@@ -57,6 +57,7 @@ textarea {
 
 /* Position the online count button a bit better */
 li[data-key=showusers] > a #online_count {
+    background-color: #000;
     -webkit-border-radius: 4px !important;
        -moz-border-radius: 4px !important;
             border-radius: 4px !important;
@@ -66,6 +67,11 @@ li[data-key=showusers] > a #online_count {
     padding: 3px 4px;
     right: 1px;
     top: 5px;
+}
+
+li[data-key=showusers] > a:focus #online_count,
+li[data-key=showusers] > a:hover #online_count {
+    background-color: #999;
 }
 
 /* Hide chat */

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -57,8 +57,6 @@ exports.postAceInit = function (hook_name, args, cb) {
  */
 
 updateUserCount = function() {
-    // Restore classes that etherpad may remove
-    $('#online_count').addClass('badge badge-important');
     // No need to show a badge if only one user is accessing the document
     if ($('#online_count').text() === "1") {
         $('#online_count').hide();


### PR DESCRIPTION
On Jul 6, 2015, at 6:36 AM, Mathilde GUERIN <mathilde.guerin@univ-lr.fr> wrote:

Hi all,

I am not sure whether this is a bug in or not so I thought it would be better to ask on the list before creating an issue.
=> When editing an Etherpard document, how come the number of users currently accessing the document is not displayed anymore? The list of users is still there (when you click on the icon) but the counter next to the "user icon" is gone. 
Was it disabled on purpose (like some other Etherpad functions) in the latest versions (I think it goes back to at least v11.2.0) or is it a side effect from the upgrade?

Note: I do not think this is specific to our "ESUP" instance but I may be wrong... 

If this is indeed a bug, do you want me to create a issue on Github?
Best
MG
